### PR TITLE
Added: sorting by bind requests cache size (least bind requests cache amount first)

### DIFF
--- a/awo_testwork_router-main/src/router/cache.py
+++ b/awo_testwork_router-main/src/router/cache.py
@@ -278,7 +278,10 @@ class RedisCache(BaseCache):
 
     def _get_size(self) -> int:
         return self._client.dbsize()
-    
+
+    def get_size(self) -> int:
+        return self._client.dbsize()
+
 
 class HTTPCache(RedisCache):
 

--- a/awo_testwork_router-main/src/router/manager.py
+++ b/awo_testwork_router-main/src/router/manager.py
@@ -142,6 +142,7 @@ class Manager:
                     key=lambda _: (
                         _.account.cost,
                         _.account.last_req_timestamp or self.nodatetime,
+                        _.manager.bind_requests_cache.get_size()    # Sort by bind requests cache size
                     )
                 )
             ]

--- a/awo_testwork_router-main/src/router/worker.py
+++ b/awo_testwork_router-main/src/router/worker.py
@@ -72,6 +72,10 @@ class AsyncWorker:
         return self._account
 
     @property
+    def manager(self) -> 'Manager':
+        return self._manager
+
+    @property
     def state(self) -> WorkerState:
         return self._state
 


### PR DESCRIPTION
Added: Property method manager to Worker class and non-private get_size() method for RedisCache class.
Changed: Worker's candidates list sorting to get worker with the least amount of binds. 